### PR TITLE
feat: Use `HashRouter` instead of `BrowserRouter`

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,7 @@
+# This is a config for Netlify to redirect the following
+# routes to the HashRouter representation
+/           /#/
+/cities     /#/cities
+/articles   /#/articles
+/profile    /#/profile
+/*          /#/

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route } from 'react-router-dom'
+import { HashRouter as Router, Route } from 'react-router-dom'
 import Navigation from "../components/Navigation"
 import Home from '../pages/Home'
 import Cities from '../pages/Cities'


### PR DESCRIPTION
This switch is because the HashRouter can show the correct page if a user reloads the website or directly navigates to a specific page.